### PR TITLE
fix: update order status when invoice is created

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -87,6 +87,15 @@ class Data extends AbstractHelper
         return $this->getModuleGeneralConfig('mode');
     }
 
+    /**
+     * @return mixed|string
+     */
+    public function getStatusToPaidOrder()
+    {
+        $status = $this->getModuleGeneralConfig('paid_order_status');
+        return $status ?: Order::STATE_PROCESSING;
+    }
+
     public function getStatusToOrderComplete()
     {
         $status = $this->getModuleGeneralConfig('order_status');

--- a/Helper/WebHookHandlers/BillPaid.php
+++ b/Helper/WebHookHandlers/BillPaid.php
@@ -112,8 +112,8 @@ class BillPaid
             );
         } else {
             $order->addCommentToStatusHistory(
-                __('The payment was confirmed and the order is beeing processed')->getText(),
-                $this->helperData->getStatusToOrderComplete()
+                __('The payment was confirmed and the order is being processed')->getText(),
+                $this->helperData->getStatusToPaidOrder()
             );
         }
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -101,6 +101,11 @@
                     <label>New Order Status</label>
                     <source_model>Magento\Sales\Model\Config\Source\Order\Status</source_model>
                 </field>
+                <field id="paid_order_status" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="110"
+                       translate="label" type="select">
+                    <label>Paid Order Status</label>
+                    <source_model>Magento\Sales\Model\Config\Source\Order\Status</source_model>
+                </field>
             </group>
         </section>
 

--- a/i18n/pt_BR.csv
+++ b/i18n/pt_BR.csv
@@ -12,7 +12,7 @@
 "Error while interpreting webhook 'bill_created'","Erro ao interpretar webhook 'bill_created'."
 "There is no cycle %s of signature %d.","Ainda não existe um pedido para ciclo %s da assinatura: %d."
 "Generating invoice for the order %s.","Gerando fatura para o pedido: %s."
-"The payment was confirmed and the order is beeing processed","O pagamento foi confirmado e o pedido está sendo processado."
+"The payment was confirmed and the order is being processed","O pagamento foi confirmado e o pedido está sendo processado."
 "Impossible to generate invoice for order %s.","Impossível gerar fatura para o pedido %s."
 "Invoice created with success","Fatura gerada com sucesso."
 "Order not found","Pedido não encontrado."
@@ -132,3 +132,4 @@
 "Pay up: %s","Pague até: %s"
 "Enabled document","Ativar documento"
 "When enabled, it will only be possible to finalize the order with the document informed when selecting the payment method. When disabled, the client will not be asked for the document, but it will still be necessary to send the document when creating the order in VINDI, otherwise it will be rejected by the API.","Quando habilitado, só será possível finalizar o pedido com o documento informado ao selecionar o método de pagamento. Quando desabilitado, não será solicitado ao cliente o documento, porém ainda será necessário o envio do documento ao criar o pedido na VINDI, caso contrário será rejeitado pela API."
+"Paid Order Status","Status de Pedido Pago"


### PR DESCRIPTION
## O que mudou
Foi adicionada uma nova config para que seja possível selecionar qual o status do pedido quando ele for pago e fatura for criada no Magento. 

## Motivação
Quando um pagamento estava sendo confirmado na Vindi, a loja Magento estava sendo notificada da alteração para que a fatura fosse criada, porém o status do pedido não era atualizado, ficando sempre como pendente. 

## Solução proposta
Em "Vindi -> Configurações -> Geral" foi adicionada a config "Status de Pedido Pago" onde é possível escolher o status que o pedido deve ter quando o pagamento for realizado. Quando o módulo cria a fatura, essa config esta sendo consultada e o status do pedido é atualizado.  

## Como testar
- Selecione o status desejado em "Vindi -> Configurações -> Geral -> Status de Pedido Pago"
- Crie um pedido com fatura avulsa 
- Faça a captura do pagamento na Vindi
- Verifique se a loja foi notificada e se o status foi atualizado para o selecionado na config