### PR TITLE
fix: display installments with shipping amount

### DIFF
--- a/Model/ConfigProvider.php
+++ b/Model/ConfigProvider.php
@@ -93,50 +93,14 @@ class ConfigProvider implements ConfigProviderInterface
                     'months' => [$this->_methodCode => $this->ccConfig->getCcMonths()],
                     'years' => [$this->_methodCode => $this->ccConfig->getCcYears()],
                     'hasVerification' => [$this->_methodCode => $this->ccConfig->hasVerification()],
-                    'installments' => [$this->_methodCode => $this->getInstallments()],
+                    'isInstallmentsAllowedInStore' => (int) $this->helperData->isInstallmentsAllowedInStore(),
+                    'maxInstallments' => (int) $this->helperData->getMaxInstallments() ?: 1,
+                    'minInstallmentsValue' => (int) $this->helperData->getMinInstallmentsValue(),
+                    'hasPlanInCart' => (int) $this->hasPlanInCart(),
+                    'planIntervalCountMaxInstallments' => (int) $this->planIntervalCountMaxInstallments()
                 ]
             ]
         ];
-    }
-
-    public function getInstallments()
-    {
-        $allowInstallments = $this->helperData->isInstallmentsAllowedInStore();
-        $maxInstallmentsNumber = $this->helperData->getMaxInstallments();
-        $minInstallmentsValue = $this->helperData->getMinInstallmentsValue();
-
-        $quote =  $this->checkoutSession->getQuote();
-        $installments = [];
-
-        if ($this->hasPlanInCart()) {
-            $planInterval = $this->planIntervalCountMaxInstallments();
-            if ($planInterval < $maxInstallmentsNumber) {
-                $maxInstallmentsNumber = $planInterval;
-            }
-        }
-
-        if ($maxInstallmentsNumber > 1 && $allowInstallments == true) {
-            $total = $quote->getGrandTotal();
-            $installmentsTimes = floor($total / $minInstallmentsValue);
-
-            for ($i = 1; $i <= $maxInstallmentsNumber; $i++) {
-                $value = ceil($total / $i * 100) / 100;
-                $price = $this->currency->format($value, null, null, false);
-                $installments[$i] = $i . " de " . $price;
-                if (($i + 1) > $installmentsTimes) {
-                    break;
-                }
-            }
-        } else {
-            $installments[1] = 1 . " de " . $this->currency->format(
-                $quote->getGrandTotal(),
-                null,
-                null,
-                false
-                );
-        }
-
-        return $installments;
     }
 
     /**

--- a/view/frontend/web/template/payment/cc-form.html
+++ b/view/frontend/web/template/payment/cc-form.html
@@ -146,7 +146,7 @@
                                 class="select credit-card-installments"
                                 data-bind="attr: {id: getCode() + '_installments', 'data-container': getCode() + '-installments', 'data-validate': JSON.stringify({required:true, 'validate-cc-exp':'#' + getCode() + '_expiration_yr'})},
                                             enable: isActive($parents),
-                                            options: getCcInstallmentsAvailable(),
+                                            options: creditCardInstallments,
                                             optionsValue: 'value',
                                             optionsText: 'text',
                                             optionsCaption: $t('Installments'),


### PR DESCRIPTION
## O que mudou
O calculo de parcelamento passou a ser feito utilizando javascript.

## Motivação
Ao acessar o checkout pela primeira as informações de parcela eram consultadas, porém nesse momento a opção de frete ainda não havia sido escolhida, gerando uma divergencia entre o valor utilizado para calculo das parcelas e o valor real do pedido.

## Solução proposta
O calculo de parcelamento deve ser feito pelo javascript que é chamado quando o método de pagamento é escolhido, dessa forma o valor de grand_total utilizado já esta atualizado com o valor de frete escolhido. E caso algum cupom seja aplicado o valor também será atualizado. 

## Como testar
Habilite o parcelamento nas compras com cartão de crédito
Vá para a finalização de pedido
Verifique se as opções de parcelamento exibidas consideram o valor de frete
