### PR TITLE
Bloqueado Pix e Boleto para assinaturas com faturamento após a data d…

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -4,7 +4,7 @@ namespace Vindi\Payment\Helper;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Eav\Api\AttributeSetRepositoryInterface;
-use \Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Sales\Model\Order;
@@ -100,7 +100,7 @@ class Data extends AbstractHelper
     {
         $status = $this->getModuleGeneralConfig('order_status');
 
-        return $status ? : Order::STATE_PROCESSING;
+        return $status ?: Order::STATE_PROCESSING;
     }
 
     public function getBaseUrl()
@@ -117,10 +117,15 @@ class Data extends AbstractHelper
      */
     public static function sanitizeItemSku($code)
     {
-        return strtolower( preg_replace("[^a-zA-Z0-9-]", "-",
-            strtr(utf8_decode(trim(preg_replace('/[ -]+/' , '-' , $code))),
+        return strtolower(preg_replace(
+            "[^a-zA-Z0-9-]",
+            "-",
+            strtr(
+                utf8_decode(trim(preg_replace('/[ -]+/', '-', $code))),
                 utf8_decode("áàãâéêíóôõúüñçÁÀÃÂÉÊÍÓÔÕÚÜÑÇ"),
-                "aaaaeeiooouuncAAAAEEIOOOUUNC-")));
+                "aaaaeeiooouuncAAAAEEIOOOUUNC-"
+            )
+        ));
     }
 
     /**
@@ -133,5 +138,15 @@ class Data extends AbstractHelper
         $product = $this->productRepository->getById($productId);
         $attrSet = $this->attributeSetRepository->get($product->getAttributeSetId());
         return $attrSet->getAttributeSetName() == UpgradeData::VINDI_PLANOS;
+    }
+
+    /**
+    * @param $productId
+    * @return \Magento\Catalog\Api\Data\ProductInterface
+    * @throws NoSuchEntityException
+    */
+    public function getProductById($productId)
+    {
+        return $this->productRepository->getById($productId);
     }
 }


### PR DESCRIPTION
## O que mudou
_Adicionado validação para bloqueio de métodos de pagamento Pix e Boleto no checkout ao comprar produtos assinatura com faturamento após a data do pedido._

## Motivação
_Foi solicitado o bloqueio destes métodos para estes casos, até que seja realizada uma solução completa._

## Solução proposta
_Remover Pix e Boleto para produtos com faturamento após a data do pedido._

## Como testar
_Adicionar um produto assinatura com faturamento após a data do pedido, e chegar até o checkout no passo de pagamento._
