### PR TITLE
Bloqueado Pix e Boleto também para assinaturas com cobrança Termino do Periodo

### DIFF
--- a/Model/Payment/AbstractMethod.php
+++ b/Model/Payment/AbstractMethod.php
@@ -187,7 +187,8 @@ abstract class AbstractMethod extends OriginAbstractMethod
             foreach ($quote->getItems() as $item) {
                 if ($this->helperData->isVindiPlan($item->getProductId())) {
                     $product = $this->helperData->getProductById($item->getProductId());
-                    if ($product->getData('vindi_billing_trigger_day') > 0) {
+                    if ($product->getData('vindi_billing_trigger_day') > 0 ||
+                        $product->getData('vindi_billing_trigger_type') == 'end_of_period') {
                         return false;
                     }
                 }


### PR DESCRIPTION
## O que mudou
_Adicionado validação para bloqueio de métodos de pagamento Pix e Boleto no checkout ao comprar produtos assinatura com faturamento após a data do pedido._

## Motivação
_Foi solicitado o bloqueio destes métodos para estes casos, até que seja realizada uma solução completa._

## Solução proposta
_Remover Pix e Boleto para produtos com faturamento após a data do pedido._

## Como testar
_Adicionar um produto assinatura com faturamento após a data do pedido, e chegar até o checkout no passo de pagamento._
